### PR TITLE
Add set-output to Docker entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,5 +46,11 @@ install_driftctl || log_error "Fail to install driftctl"
 qflag=""
 quiet_flag
 
+# Store driftctl scan in variable to be used by output
+driftctl=$(driftctl scan $qflag $INPUT_ARGS)
+
+# Set output to be used for other Github Actions jobs
+echo ::set-output name=driftct::$driftctl
+
 # Finally we run the scan command
 driftctl scan $qflag $INPUT_ARGS


### PR DESCRIPTION
> Q 	A
> 🐛 Bug fix? 	no
> 🚀 New feature? 	yes
> ⚠ Deprecations? 	no
> ❌ BC Break 	no
> 🔗 Related issues 	NA
> ❓ Documentation 	yes
> ## Description
> 
> This PR adds [set-output](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) to the Docker entry point shell script to enable driftctl stdout to be consumed by other GitHub Actions jobs downstream.